### PR TITLE
Add df output functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ parquet/
 parquet2/
 __pycache__
 scratch/
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
-# Darshan-DataFramer
+# wfmeta-darshan
 
-Package to take the output of darshan logs and collect them into dataframes for storage, analysis, and (hopefully) combination with DASK metadata to form a complete picture of a workflow's tasks' metadata.
+Python module that, given a directory of Darshan logs, reads them into Log objects and aggregates the modules across independent Darshan log files. It then writes these aggregated module statistics into csv files using Pandas DataFrames, as well as a file describing metadata about the collected files themselves.
+
+## Usage
+
+```
+usage: wfmeta_darshan [-h] [-d] input output
+
+positional arguments:
+  input        Relative directory containing the darshan logs to parse and
+               aggregate.
+  output       Relative directory to write the aggregated data.
+
+options:
+  -h, --help   show this help message and exit
+  -d, --debug  If true, prints additional debug messages during runtime.
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,16 @@
 [project]
 name = "wfmeta-darshan"
 version = "0.1.0"
-description = "Add your description here"
+description = "wfmeta Tool to read and aggregate Darshan logs."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 dependencies = [
-    "darshan>=3.4.5.0",
-    #"darshan @ git+https://github.com/darshan-hpc/darshan@snyder/dxt-extra-info-pthread-id#egg=darshan&subdirectory=darshan-util/pydarshan",
-    "ipykernel>=6.29.5",
     "pyarrow>=17.0.0",
     "pandas",
 ]
+
+[project.scripts]
+wfmeta-darshan = "wfmeta_darshan:create_parser_and_run"
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "wfmeta-darshan"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 dependencies = [
     "darshan>=3.4.5.0",
     #"darshan @ git+https://github.com/darshan-hpc/darshan@snyder/dxt-extra-info-pthread-id#egg=darshan&subdirectory=darshan-util/pydarshan",

--- a/share/docker/run_darshan_container_dev.sh
+++ b/share/docker/run_darshan_container_dev.sh
@@ -24,8 +24,9 @@ datapath=$(to-abs-path $2)
 #customrepopath=$(to-abs-path ~/spack_custom_repo)
 
 docker run \
+    -p 8888:8888 \
 	-v $codepath:/resource/code \
 	-v $datapath:/resource/data \
 	--interactive \
 	--tty \
-	infiloop/wfmeta_darshan_util_dxtthread:dev
+	infiloop/wfmeta_darshan_util_dxtthread_dev:dev

--- a/src/wfmeta_darshan/__init__.py
+++ b/src/wfmeta_darshan/__init__.py
@@ -1,157 +1,20 @@
+import argparse
+import pathlib
 from typing import Any, Dict, List
 from functools import reduce
 import darshan
 import os
 import pandas as pd
 
-from wfmeta_darshan.objs.log import Log
+from .objs.log import Log, LogCollection
 
-from .objs.colls import POSIX_coll, LUSTRE_coll, DXT_POSIX_coll, STDIO_coll, CounterCollColl
+from .objs.colls import POSIX_coll, LUSTRE_coll, DXT_POSIX_coll, STDIO_coll
 
 #####################################################
 # Main functions                                    #
 #####################################################
 
-def read_log(filename:str, debug:bool = False) -> Dict[str, Any]:
-    """Read the provided `.darshan` log file.
-    
-    Manually reads in the provided `.darshan` log file by loading in its
-    core report data, then manually importing each module it sees.
-    Importantly, it does not import the `HEATMAP` module.
-
-    It skips the `HEATPMAP` module because the `pydarshan` package
-    itself states: 
-    ```
-    Currently unsupported: HEATMAP in mod_read_all_records().
-    ```
-    """
-    if debug :
-        print("\tReading darshan log %s" % filename)
-    
-    if not os.path.exists(filename) :
-        raise ValueError("Provided path %s does not exist." % filename)
-    if not os.path.isfile(filename) :
-        raise ValueError("Provided path %s is not a valid file." % filename)
-    
-    if debug :
-        print("\tFile exists. Moving on...")
-
-    output: Dict = {}
-    with darshan.DarshanReport(filename, read_all=True) as report :
-        if debug :
-            print("File successfully opened as a report.")
-
-        # Get metadata
-        output["metadata"] = report.metadata
-
-        juid: str = report.metadata['job']['uid']
-        jobid: str = report.metadata['job']['jobid']
-
-        # Get list of modules
-        expected_modules = ["POSIX", "LUSTRE", "STDIO", "DXT_POSIX", "HEATMAP", "MPI-IO", "DXT_MPIIO"]
-        modules = list(report.modules.keys())
-        output["modules"] = modules
-        
-        if debug :
-            print("\tFound modules: %s" % ",".join(modules))
-
-        for m in modules :
-            if m not in expected_modules :
-                print("unexpected module found: %s" % m)
-
-        loaded_modules = []
-
-        # Get data for each found module
-        if "POSIX" in modules :
-            output["POSIX_coll"] = POSIX_coll(report.records["POSIX"], juid, jobid)
-            loaded_modules.append("POSIX_coll")
-        
-        if "LUSTRE" in modules :
-            output["LUSTRE_coll"] = LUSTRE_coll(report.records["LUSTRE"], juid, jobid)
-            loaded_modules.append("LUSTRE_coll")
-
-        if "STDIO" in modules :
-            output["STDIO_coll"] = STDIO_coll(report.records["STDIO"], juid, jobid)
-            loaded_modules.append("STDIO_coll")
-
-        if "DXT_POSIX" in modules :
-            # created a custom output object to deal with it
-            output["DXT_POSIX_coll"] = DXT_POSIX_coll(report.records['DXT_POSIX'], juid, jobid)
-            loaded_modules.append("DXT_POSIX_coll")
-
-        # Received message: Skipping. Currently unsupported: HEATMAP in mod_read_all_records().
-        # if "HEATMAP" in modules :
-        #     report.mod_read_all_records("HEATMAP", dtype="numpy")
-        #     output["HEATMAP"] = report.records["HEATMAP"].to_df()
-
-        if "MPI-IO" in modules :
-            print("############### MPI IO ###############")
-            print(report.records["MPI-IO"])
-
-        if "DXT_MPIIO" in modules :
-            print("############### DXT MPI IO ###############")
-            print(report.records["DXT_MPIIO"])
-    
-    output["report"] = report
-    output["loaded_modules"] = loaded_modules
-
-    return output
-
-def collect_metadata(reports: List[Dict], debug: bool = False) -> pd.DataFrame:
-    # available metadata per log:
-    # 'job':
-    #   'uid': 37993, 
-    #   'start_time_sec': 1713455670, 
-    #   'start_time_nsec': 57152534, 
-    #   'end_time_sec': 1713455883, 
-    #   'end_time_nsec': 91904150, 
-    #   'nprocs': 1, 
-    #   'jobid': 11298, 
-    #   'run_time': 213.03475165367126, 
-    #   'log_ver': '3.41', 
-    #   'metadata': 
-    #       'lib_ver': '3.4.4', 
-    #       'h': 'romio_no_indep_rw=true;cb_nodes=4'
-    # 'exe': '/home/agueroudji/spack/var/spack/environments/mofkadask/.spack-env/._view/ycbghmgvq7z34ridg4nntzus2jsgkcos/bin/python3.10 /home/agueroudji/spack/var/spack/environments/mofkadask/.spack-env/view/bin/dask worker --scheduler-file=scheduler.json --preload MofkaWorkerPlugin.py --mofka-protocol=cxi --ssg-file=mofka.ssg '
-
-    metadata_df_coll: List[pd.DataFrame] = []
-    header: List[str] = ['uid', 'jobid', 
-                         'start_time_sec', 'start_time_nsec',
-                         'end_time_sec', 'end_time_nsec',
-                         'nprocs', 'run_time',
-                         'log_ver',
-                         'meta.lib_ver', 'meta.h', 'exe']
-    
-    known_modules = ["POSIX", "LUSTRE", "STDIO", "DXT_POSIX", "HEATMAP", "MPI-IO", "DXT_MPIIO"]
-
-    for module in known_modules:
-        header.append("has_%s" % module)
-
-    for report in reports :
-        metadata: Dict[str, Any] = report['metadata']
-        j_m: Dict[str, Any] = metadata['job']
-        j_d: List = [j_m['uid'], j_m['jobid'], 
-                     j_m['start_time_sec'], j_m['start_time_nsec'],
-                     j_m['end_time_sec'], j_m['end_time_nsec'],
-                     j_m['nprocs'], j_m['run_time'],
-                     j_m['log_ver'],
-                     j_m['metadata']['lib_ver'],
-                     j_m['metadata']['h'],
-                     metadata['exe']]
-        
-        for module in known_modules:
-            if module in report['modules'] :
-                j_d.append(True)
-            else :
-                j_d.append(False)
-
-        metadata_df_coll.append(pd.DataFrame([j_d]))
-    
-    output_df: pd.DataFrame = pd.concat(metadata_df_coll)
-    output_df.columns = header
-    return output_df
-
-def collect_logfiles(directory:str, debug:bool = False) -> List[str]:
+def collect_log_files(directory:str, debug:bool = False) -> List[str]:
     """Collects all the `.darshan` log files in the provided directory.
 
     Collects all the `.darshan` log files in the provided direction,
@@ -180,69 +43,15 @@ def collect_logfiles(directory:str, debug:bool = False) -> List[str]:
 
     return logfiles
 
-def write_to_parquet(report_data: Dict[str, Dict], 
-                     metadata_df: pd.DataFrame, 
-                     output_dir: str, debug: bool = False) -> None:
-    
-    if os.path.exists(output_dir) and not os.path.isdir(output_dir) :
-        raise ValueError("Provided directory %s exists and is not a directory. Aborting." % output_dir)
-
-    elif os.path.exists(output_dir) :
-        if debug:
-            print("Path exists and is a directory. Proceeding.")
-
-    elif not os.path.exists(output_dir) :
-        if debug:
-            print("Provided directory does not exist. Creating.")
-        os.mkdir(output_dir)
-
-    metadata_df_filename = os.path.join(output_dir, "metadata.parquet")
-    metadata_df.to_parquet(metadata_df_filename)
-
-    if debug:
-        print("Metadata df written to %s." % metadata_df_filename)
-
-    # tmp_keys = list(report_data.keys())
-    # print(tmp_keys[0])
-    # print(report_data[tmp_keys[0]])
-    # print(report_data[tmp_keys[0]]['POSIX'])
-    # a = (report_data[tmp_keys[0]]['POSIX_coll'] + report_data[tmp_keys[1]]['POSIX_coll'])
-    # print(a)
-    # print(report_data[tmp_keys[0]]['report_ids'])
-    # print(report_data[tmp_keys[1]]['report_ids'])
-    # print(a.collection['juid'].unique())
-    # print(a.collection['jobid'].unique())
-
-    # b = a + report_data[tmp_keys[2]]['LUSTRE_coll']
-    # print(b.collection['jobid'].unique())
-    # exit(0)
-
-    all_modules: Dict[str, Any] = {}
-
-    for report_name in list(report_data.keys()) :
-        report: Dict = report_data[report_name]
-
-        loaded_modules: List[str] = report["loaded_modules"]
-
-        for module_name in loaded_modules :
-            if module_name not in all_modules.keys() :
-                all_modules[module_name] = [report[module_name]]
-            else :
-                all_modules[module_name].append(report[module_name])
-            #report[module_name].export_parquet(output_dir, report_name)
-    
-    for module in list(all_modules.keys()) :
-        res: CounterCollColl = reduce(lambda x,y: x+y, all_modules[module])
-        res.export_parquet(output_dir)
-
-    if debug:
-        print("Done writing parquet files!")
-
 def read_log_files(files: List[str], debug: bool = False) -> List[Log]:
     logs: List[Log] = []
     for f in files :
+        if debug:
+            print("\tReading %s" % f)
         logs.append(Log.From_File(f))
     
+    if debug:
+        print("Done reading files.")
     return logs
 
 def aggregate_darshan(directory:str, output_loc:str, debug:bool = False) :
@@ -252,12 +61,15 @@ def aggregate_darshan(directory:str, output_loc:str, debug:bool = False) :
     directory and reads what data is available. Then compiles all of
     their data into a new `pandas.DataFrame` and ... TODO
     '''
-    files: List[str] = collect_logfiles(directory, debug)
+    files: List[str] = collect_log_files(directory, debug)
 
     if debug:
         print("Beginning to collect log data...")
 
-    logs: List[Log] = read_log_files(files, debug)
+    files_full = [pathlib.Path(directory, x).__str__() for x in files]
+    logs: List[Log] = read_log_files(files_full, debug)
+    
+    log_coll: LogCollection = LogCollection(logs)
     
     if debug:
         print("Done collecting data!")
@@ -269,13 +81,29 @@ def aggregate_darshan(directory:str, output_loc:str, debug:bool = False) :
 
     if debug:
         print("Done collecting metadata!")
+        print("Saving metadata to csv.")
 
-    # write_to_parquet(collected_report_data, metadata_df, output_loc, debug)
+    metadata_df.to_csv(pathlib.Path(output_loc, "metadata.csv"))
 
-    # TODO : perform some statistics.
-    #           e.g. how many of each type of module is present
-    #           size ranges of data stored
+    if debug:
+        print("Done saving metadata.")
+        print("Writing aggregated module data to csvs.")
 
-    # TODO : output in some format
-    
-    # write_to_json(output_loc, collected_report_data, debug)
+    for module in Log.expected_modules :
+        module_dfs: Dict[str, pd.DataFrame] = log_coll.get_module_as_df(module)
+        for dfname, df in module_dfs.items() :
+            if debug:
+                print("\tWriting aggregated %s data to csv." % module)
+            df.to_csv(pathlib.Path(output_loc, module + "_" + dfname + ".csv"))
+
+def create_parser_and_run() :
+    parser = argparse.ArgumentParser(prog="wfmeta-darshan")
+    parser.add_argument("input",
+                        help="Relative directory containing the darshan logs to parse and aggregate.")
+    parser.add_argument("-d", "--debug", action="store_true",
+                        help="If true, prints additional debug messages during runtime.")
+    parser.add_argument("output", default="output/",
+                        help="Relative directory to write the aggregated data.")
+    args = parser.parse_args()
+
+    aggregate_darshan(args.input, args.output, args.debug)

--- a/src/wfmeta_darshan/__main__.py
+++ b/src/wfmeta_darshan/__main__.py
@@ -2,13 +2,13 @@ import argparse
 from wfmeta_darshan import aggregate_darshan
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("directory",
+    parser = argparse.ArgumentParser(prog="wfmeta_darshan")
+    parser.add_argument("input",
                         help="Relative directory containing the darshan logs to parse and aggregate.")
     parser.add_argument("-d", "--debug", action="store_true",
                         help="If true, prints additional debug messages during runtime.")
-    parser.add_argument("--output", default="parquet/",
-                        help="Where to write the JSON dump of the aggregated DARSHAN logs.")
+    parser.add_argument("output", default="output/",
+                        help="Relative directory to write the aggregated data.")
     args = parser.parse_args()
 
-    aggregate_darshan(args.directory, args.output, args.debug)
+    aggregate_darshan(args.input, args.output, args.debug)

--- a/src/wfmeta_darshan/objs/__init__.py
+++ b/src/wfmeta_darshan/objs/__init__.py
@@ -1,1 +1,2 @@
 from . import colls
+from .log import Log

--- a/src/wfmeta_darshan/objs/__init__.py
+++ b/src/wfmeta_darshan/objs/__init__.py
@@ -1,2 +1,2 @@
 from . import colls
-from .log import Log
+from .log import Log, LogCollection

--- a/src/wfmeta_darshan/objs/log.py
+++ b/src/wfmeta_darshan/objs/log.py
@@ -1,0 +1,142 @@
+import logging
+from typing import Any, Dict, List, Union
+from darshan import DarshanReport
+import darshan
+import pandas as pd
+from .colls import POSIX_coll, LUSTRE_coll, STDIO_coll, DXT_POSIX_coll
+
+class Log:
+    metadata: Dict[str, Any]
+    juid: str
+    jobid: str
+
+    expected_modules = ["POSIX", "LUSTRE", "STDIO", "DXT_POSIX", "HEATMAP", "MPI-IO", "DXT_MPIIO"]
+    loaded_modules: List[str]
+
+    POSIX: POSIX_coll
+    LUSTRE: LUSTRE_coll
+    STDIO: STDIO_coll
+    DXT_POSIX: DXT_POSIX_coll
+
+    report: Any
+    modules: List[str]
+
+    def __init__(self, report: DarshanReport) :
+        self.metadata = report.metadata
+        self.juid = report.metadata['job']['uid']
+        self.jobid = report.metadata['job']['jobid']
+        self.report = report
+
+        self.modules = list(report.modules.keys())
+
+        self.loaded_modules = []
+
+        for m in self.modules:
+            if m not in self.expected_modules :
+                print("Unexpected module found: %s" % m)
+
+            match m:
+                case "POSIX":
+                    self.POSIX = POSIX_coll(report.records[m], self.juid, self.jobid)
+                    self.loaded_modules.append(m)
+                case "LUSTRE":
+                    self.LUSTRE = LUSTRE_coll(report.records[m], self.juid, self.jobid)
+                    self.loaded_modules.append(m)
+                case "STDIO":
+                    self.STDIO = STDIO_coll(report.records[m], self.juid, self.jobid)
+                    self.loaded_modules.append(m)
+                case "DXT_POSIX":
+                    self.DXT_POSIX = DXT_POSIX_coll(report.records[m], self.juid, self.jobid)
+                    self.loaded_modules.append(m)
+
+    def get_metadata_df(self) -> pd.DataFrame:
+        j_m: Dict[str, Any] = self.metadata['job']
+        j_d: List = [j_m['uid'], j_m['jobid'], 
+                     j_m['start_time_sec'], j_m['start_time_nsec'],
+                     j_m['end_time_sec'], j_m['end_time_nsec'],
+                     j_m['nprocs'], j_m['run_time'],
+                     j_m['log_ver'],
+                     j_m['metadata']['lib_ver'],
+                     j_m['metadata']['h'],
+                     self.metadata['exe']]
+        
+        for module in self.expected_modules:
+            if module in self.report.modules.keys():
+                j_d.append(True)
+            else :
+                j_d.append(False)
+        
+        return pd.DataFrame([j_d])
+
+    def get_module_as_df(self, module_name: str) -> Union[pd.DataFrame, Dict[str, pd.DataFrame]] :
+        if module_name not in self.expected_modules :
+            logging.error("Attempted to get a module from a log that is never coded to exist: %s" % module_name)
+            exit(1)
+        
+        if module_name not in self.loaded_modules :
+            logging.warning("Tried to get module %s from a log that does not have it loaded." % module_name)
+            return pd.DataFrame()
+        
+        output = pd.DataFrame()
+        match module_name:
+            case "POSIX" :
+                output = self.POSIX.get_both_df_with_ids()
+            case "LUSTRE":
+                output = self.LUSTRE.get_df_with_ids()
+            case "STDIO":
+                output = self.STDIO.get_both_df_with_ids()
+            case "DXT_POSIX":
+                output = self.DXT_POSIX.get_both_df_with_ids()
+            case _:
+                logging.error("Attempted to access module name %s in Log switch-case that does not exist." % module_name)
+                exit(1)
+        
+        return output
+
+    @staticmethod
+    def get_total_metadata_df(logs: List['Log']) -> pd.DataFrame:
+        output_df_collection: List[pd.DataFrame] = []
+        header: List[str] = ['uid', 'jobid', 
+                         'start_time_sec', 'start_time_nsec',
+                         'end_time_sec', 'end_time_nsec',
+                         'nprocs', 'run_time',
+                         'log_ver',
+                         'meta.lib_ver', 'meta.h', 'exe']
+        for module in Log.expected_modules :
+            header.append("has_%s" % module)
+
+        for log in logs:
+            output_df_collection.append(log.get_metadata_df())
+
+        output_df: pd.DataFrame = pd.concat(output_df_collection)
+        output_df.columns = header
+
+        return output_df
+    
+    @staticmethod
+    def From_File(path: str) -> 'Log':
+        with darshan.DarshanReport(path) as report:
+            output = Log(report)
+        
+        return output
+    
+class LogCollection:
+    logs: List[Log]
+
+    def __init__(self, logs: List[Log]) :
+        self.logs = logs
+
+    def GetAllOfModule(self, module_name: str) -> Union[pd.DataFrame, List[pd.DataFrame]] :
+        output: pd.DataFrame = pd.DataFrame()
+
+        if module_name not in Log.expected_modules :
+            logging.error("Provided module name %s, which is not expected." % module_name)
+            exit(1)
+
+        collected_dfs = []
+        for l in self.logs :
+            if module_name in l.loaded_modules :
+                df = l.get_module(module_name)
+
+
+        return output


### PR DESCRIPTION
Main functionality is officially actually completed!

Restructured code:
- Made `wfmeta-darshan` installable as a package (publishing package is the next step)
- Now log files are read in as `wfmeta-darshan.Log` objects, which are collected into a `wfmeta-darshan.LogCollection` object.
- `LogCollection` object combines modules across `Log`s.
- Module objects (e.g. `POSIX_coll`, `LUSTRE_coll`) add the `juid` and `jobid` of the `Log` they came from, if not already part of the data, to ensure data from separate logs is still distinguishable after aggregation.
- `LogCollection` also writes a csv containing cross-log metadata, such as the `jobid`s and `juid`s of the various logs.